### PR TITLE
Fix priompt-preview dialog component

### DIFF
--- a/priompt-preview/package.json
+++ b/priompt-preview/package.json
@@ -63,7 +63,7 @@
     }
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",

--- a/priompt-preview/src/components/ui/dialog.tsx
+++ b/priompt-preview/src/components/ui/dialog.tsx
@@ -8,13 +8,9 @@ const Dialog = DialogPrimitive.Root
 
 const DialogTrigger = DialogPrimitive.Trigger
 
-const DialogPortal = ({
-  className,
-  ...props
-}: DialogPrimitive.DialogPortalProps) => (
-  <DialogPrimitive.Portal className={cn(className)} {...props} />
-)
-DialogPortal.displayName = DialogPrimitive.Portal.displayName
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -112,7 +108,10 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName
 
 export {
   Dialog,
+  DialogPortal,
+  DialogOverlay,
   DialogTrigger,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogFooter,


### PR DESCRIPTION
`@radix-ui/react-dialog` on version v1.0.5 removes the `className` prop from the `Portal` component, causing a Typescript error. This can be fixed by either pinning the dependency to =1.0.4 or by updating to 1.0.5 and fixing the error.

This PR fixes this by bumping `@radix-ui/react-dialog` to 1.0.5 and removing the unneeded props from the dialog component.

**NOTE:** I suspect that priompt is a part of a larger monorepo, so bumping `@radix-ui/react-dialog` may require more changes outside the scope of this repo.