### PR TITLE
Create props type per intrinsic element

### DIFF
--- a/priompt/src/base.test.tsx
+++ b/priompt/src/base.test.tsx
@@ -236,4 +236,33 @@ describe("isolate", () => {
     const toTokens = await promptToTokens(specialTokens.prompt, "cl100k_base");
     expect(specialTokens.tokenCount).toBe(toTokens.length);
   });
+
+  function EmptyPrompt(
+    props: PromptProps<{ tokenLimit: number }>
+  ): PromptElement {
+    return (
+      <>
+        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore */}
+        <isolate tokenLimit={props.tokenLimit}>
+          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore */}
+          <empty tokens={props.tokenLimit + 1} />
+        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore */}
+        </isolate>
+      </>
+    );
+  }
+
+  it("empty element reserves tokens", async () => {
+    try {
+      await render(EmptyPrompt({ tokenLimit: 500 }), {
+        tokenLimit: 1000,
+        tokenizer: "cl100k_base",
+      });
+    } catch (e) {
+      expect(e.message).toContain("which is higher than the limit");
+    }
+  });
 });

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -180,7 +180,7 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 					type: 'scope',
 					children: [{
 						type: 'empty',
-						tokenCount: props.tokens,
+						tokens: props.tokens,
 					}],
 					absolutePriority: (typeof props.p === 'number') ? props.p : undefined,
 					relativePriority: (typeof props.prel === 'number') ? props.prel : undefined
@@ -855,7 +855,7 @@ async function renderWithLevelAndCountTokens(elem: NormalizedNode[] | Normalized
 			return {
 				prompt: undefined,
 				tokenCount: 0,
-				emptyTokenCount: elem.tokenCount,
+				emptyTokenCount: elem.tokens,
 				outputHandlers: [],
 				streamHandlers: []
 			}
@@ -1051,7 +1051,7 @@ function renderWithLevelAndEarlyExitWithTokenEstimation(elem: PromptElement, lev
 		case 'empty': {
 			return {
 				prompt: undefined,
-				emptyTokenCount: elem.tokenCount
+				emptyTokenCount: elem.tokens
 			}
 		}
 		case 'functionDefinition': {
@@ -1298,7 +1298,7 @@ function renderWithLevel(elem: PromptElement, level: number, tokenizer: UsableTo
 		case 'empty': {
 			return {
 				prompt: undefined,
-				emptyTokenCount: elem.tokenCount,
+				emptyTokenCount: elem.tokens,
 				outputHandlers: [],
 				streamHandlers: []
 			}


### PR DESCRIPTION
The `BaseProps` type is currently used to create the prop types of intrinsic elements. However, this is hard to read/understand and requires careful usage of the `Omit` utility type.
 
This PR creates unique prop types per intrinsic element that are (hopefully) easier to understand and maintain. This also fixes the types so that only `<first>` and `<scope>` elements can pass in `onEject` and `onInclude`.

I also chose to combine the `tokens` prop with `tokenLimit` of the `<empty>` element to just `tokens`, which required a slight change to `lib.ts`, so I added a new test for good measure.