### PR TITLE
Make `PromptNode` and `PromptElement` types more React-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ function ExamplePrompt(
     message: string,
     history: { case: "user" | "assistant", message: string },
   }>
-): PromptElement {
+): PromptNode {
   const capitalizedName = props.name[0].toUpperCase() + props.name.slice(1);
   return (
     <>

--- a/examples/src/function-calling-prompt.tsx
+++ b/examples/src/function-calling-prompt.tsx
@@ -2,7 +2,7 @@ import * as Priompt from "@anysphere/priompt";
 import {
   PreviewConfig,
   PreviewManager,
-  PromptElement,
+  PromptNode,
   PromptProps,
   SystemMessage,
   UserMessage,
@@ -32,7 +32,7 @@ const arr = Array.from(Array(800).keys());
 export function FunctionCallingPrompt(
   props: FunctionCallingPromptProps,
   args?: { dump?: boolean }
-): PromptElement {
+): PromptNode {
   if (args?.dump === true) {
     PreviewManager.dump(FunctionCallingPromptConfig, props);
   }

--- a/examples/src/prompt.tsx
+++ b/examples/src/prompt.tsx
@@ -2,7 +2,7 @@ import * as Priompt from "@anysphere/priompt";
 import {
   PreviewConfig,
   PreviewManager,
-  PromptElement,
+  PromptNode,
   PromptProps,
   SystemMessage,
   UserMessage,
@@ -22,7 +22,7 @@ export type ExamplePromptProps = PromptProps<{
 export function ExamplePrompt(
   props: ExamplePromptProps,
   args?: { dump?: boolean }
-): PromptElement {
+): PromptNode {
   if (args?.dump === true) {
     PreviewManager.dump(ExamplePromptConfig, props);
   }
@@ -50,7 +50,7 @@ export function SimplePrompt(
     },
     boolean
   >
-): PromptElement {
+): PromptNode {
   return (
     <>
       <SystemMessage>
@@ -78,7 +78,7 @@ export function SimplePrompt(
 PreviewManager.register(ArvidStory);
 export function ArvidStory(
   props: PromptProps<undefined, AsyncIterable<string>>
-): PromptElement {
+): PromptNode {
   return (
     <>
       <SystemMessage>

--- a/priompt/src/base.test.tsx
+++ b/priompt/src/base.test.tsx
@@ -7,13 +7,13 @@ import {
   promptToTokens,
   render,
 } from "./lib";
-import { PromptElement, PromptProps } from "./types";
+import { PromptNode, PromptProps } from "./types";
 import { AssistantMessage, SystemMessage, UserMessage } from "./components";
 
 describe("isolate", () => {
   function Isolate(
     props: PromptProps<{ isolate: boolean; tokenLimit: number }>
-  ): PromptElement {
+  ): PromptNode {
     if (props.isolate) {
       return (
         <>
@@ -41,7 +41,7 @@ describe("isolate", () => {
     }
   }
 
-  function Test(props: PromptProps<{ isolate: boolean }>): PromptElement {
+  function Test(props: PromptProps<{ isolate: boolean }>): PromptNode {
     return (
       <>
         This is the start of the prompt.
@@ -120,7 +120,7 @@ describe("isolate", () => {
 
   function SimplePrompt(
     props: PromptProps<{ breaktoken: boolean }>
-  ): PromptElement {
+  ): PromptNode {
     return (
       <>
         This is the start of the p
@@ -159,7 +159,7 @@ describe("isolate", () => {
 
   function SimpleMessagePrompt(
     props: PromptProps<{ breaktoken: boolean }>
-  ): PromptElement {
+  ): PromptNode {
     return (
       <>
         {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -214,7 +214,7 @@ describe("isolate", () => {
     ]);
   });
 
-  function SpecialTokensPrompt(): PromptElement {
+  function SpecialTokensPrompt(): PromptNode {
     return (
       <>
         {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/priompt/src/components.test.tsx
+++ b/priompt/src/components.test.tsx
@@ -33,7 +33,7 @@ describe("SystemMessage", () => {
 
   function TestSystemMessageWithName(
     props: PromptProps<{ systemName?: string; userName?: string }>
-  ): PromptElement {
+  ): PromptNode {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return (

--- a/priompt/src/components.test.tsx
+++ b/priompt/src/components.test.tsx
@@ -8,10 +8,10 @@ import {
   SystemMessage,
   UserMessage,
 } from "./components";
-import { PromptElement, PromptProps } from "./types";
+import { PromptNode, PromptProps } from "./types";
 
 describe("SystemMessage", () => {
-  function TestSystemMessage(props: PromptProps): PromptElement {
+  function TestSystemMessage(props: PromptProps): PromptNode {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return <SystemMessage>hi this is a system message</SystemMessage>;
@@ -27,7 +27,7 @@ describe("SystemMessage", () => {
 });
 
 describe("Function", () => {
-  function TestFunction(props: PromptProps): PromptElement {
+  function TestFunction(props: PromptProps): PromptNode {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return (
@@ -83,7 +83,7 @@ describe("Function", () => {
 });
 
 describe("All kinds of messages", () => {
-  function TestAllMessages(props: PromptProps): PromptElement {
+  function TestAllMessages(props: PromptProps): PromptNode {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return (

--- a/priompt/src/components.tsx
+++ b/priompt/src/components.tsx
@@ -5,82 +5,67 @@ import { JSONSchema7 } from "json-schema";
 import { z } from "zod";
 import zodToJsonSchemaImpl from "zod-to-json-schema";
 
-export function SystemMessage(props: PromptProps): PromptElement {
+export function SystemMessage({ children }: PromptProps): PromptElement {
   return {
     type: "chat",
     role: "system",
-    children:
-      props.children !== undefined
-        ? Array.isArray(props.children)
-          ? props.children.flat()
-          : [props.children]
-        : [],
+    children,
   };
 }
 
-export function UserMessage(props: PromptProps): PromptElement {
+export function UserMessage({ children }: PromptProps): PromptElement {
   return {
     type: "chat",
     role: "user",
-    children:
-      props.children !== undefined
-        ? Array.isArray(props.children)
-          ? props.children.flat()
-          : [props.children]
-        : [],
+    children,
   };
 }
 
-export function AssistantMessage(
-  props: PromptProps<{
-    functionCall?: {
-      name: string;
-      arguments: string; // json string
-    };
-  }>
-): PromptElement {
+export function AssistantMessage({
+  functionCall,
+  children,
+}: PromptProps<{
+  functionCall?: {
+    name: string;
+    arguments: string; // json string
+  };
+}>): PromptElement {
   return {
     type: "chat",
     role: "assistant",
-    functionCall: props.functionCall,
-    children:
-      props.children !== undefined
-        ? Array.isArray(props.children)
-          ? props.children.flat()
-          : [props.children]
-        : [],
+    functionCall,
+    children,
   };
 }
 
-export function FunctionMessage(
-  props: PromptProps<{
-    name: string;
-  }>
-): PromptElement {
+export function FunctionMessage({
+  name,
+  children,
+}: PromptProps<{
+  name: string;
+}>): PromptElement {
   return {
     type: "chat",
     role: "function",
-    name: props.name,
-    children:
-      props.children !== undefined
-        ? Array.isArray(props.children)
-          ? props.children.flat()
-          : [props.children]
-        : [],
+    name,
+    children,
   };
 }
 
-export function Function(
-  props: PromptProps<{
-    name: string;
-    description: string;
-    parameters: JSONSchema7;
-    onCall?: (args: string) => Promise<void>;
-  }>
-): PromptElement {
-  if (!validFunctionName(props.name)) {
+export function Function({
+  name,
+  description,
+  parameters,
+  onCall,
+}: PromptProps<{
+  name: string;
+  description: string;
+  parameters: JSONSchema7;
+  onCall?: (args: string) => Promise<void>;
+}>): PromptElement {
+  if (!validFunctionName(name)) {
     throw new Error(
-      `Invalid function name: ${props.name}. Function names must be between 1 and 64 characters long and may only contain a-z, A-Z, 0-9, and underscores.`
+      `Invalid function name: ${name}. Function names must be between 1 and 64 characters long and may only contain a-z, A-Z, 0-9, and underscores.`
     );
   }
 
@@ -90,20 +75,20 @@ export function Function(
     <>
       {{
         type: "functionDefinition",
-        name: props.name,
-        description: props.description,
-        parameters: props.parameters,
+        name,
+        description,
+        parameters,
       }}
       {{
         type: "capture",
         onOutput: async (output: ChatCompletionResponseMessage) => {
           if (
-            props.onCall !== undefined &&
+            onCall !== undefined &&
             output.function_call !== undefined &&
-            output.function_call.name === props.name &&
+            output.function_call.name === name &&
             output.function_call.arguments !== undefined
           ) {
-            await props.onCall(output.function_call.arguments);
+            await onCall(output.function_call.arguments);
           }
         },
       }}

--- a/priompt/src/components.tsx
+++ b/priompt/src/components.tsx
@@ -31,51 +31,46 @@ export function UserMessage(
   };
 }
 
-export function AssistantMessage({
-  functionCall,
-  children,
-}: PromptProps<{
-  functionCall?: {
-    name: string;
-    arguments: string; // json string
-  };
-}>): PromptElement {
+export function AssistantMessage(
+  props: PromptProps<{
+    functionCall?: {
+      name: string;
+      arguments: string; // json string
+    };
+  }>
+): PromptElement {
   return {
     type: "chat",
     role: "assistant",
-    functionCall,
-    children,
+    functionCall: props.functionCall,
+    children: props.children,
   };
 }
 
-export function FunctionMessage({
-  name,
-  children,
-}: PromptProps<{
-  name: string;
-}>): PromptElement {
+export function FunctionMessage(
+  props: PromptProps<{
+    name: string;
+  }>
+): PromptElement {
   return {
     type: "chat",
     role: "function",
-    name,
-    children,
+    name: props.name,
+    children: props.children,
   };
 }
 
-export function Function({
-  name,
-  description,
-  parameters,
-  onCall,
-}: PromptProps<{
-  name: string;
-  description: string;
-  parameters: JSONSchema7;
-  onCall?: (args: string) => Promise<void>;
-}>): PromptElement {
-  if (!validFunctionName(name)) {
+export function Function(
+  props: PromptProps<{
+    name: string;
+    description: string;
+    parameters: JSONSchema7;
+    onCall?: (args: string) => Promise<void>;
+  }>
+): PromptElement {
+  if (!validFunctionName(props.name)) {
     throw new Error(
-      `Invalid function name: ${name}. Function names must be between 1 and 64 characters long and may only contain a-z, A-Z, 0-9, and underscores.`
+      `Invalid function name: ${props.name}. Function names must be between 1 and 64 characters long and may only contain a-z, A-Z, 0-9, and underscores.`
     );
   }
 
@@ -85,20 +80,20 @@ export function Function({
     <>
       {{
         type: "functionDefinition",
-        name,
-        description,
-        parameters,
+        name: props.name,
+        description: props.description,
+        parameters: props.parameters,
       }}
       {{
         type: "capture",
         onOutput: async (output: ChatCompletionResponseMessage) => {
           if (
-            onCall !== undefined &&
+            props.onCall !== undefined &&
             output.function_call !== undefined &&
             output.function_call.name === name &&
             output.function_call.arguments !== undefined
           ) {
-            await onCall(output.function_call.arguments);
+            await props.onCall(output.function_call.arguments);
           }
         },
       }}

--- a/priompt/src/components.tsx
+++ b/priompt/src/components.tsx
@@ -90,7 +90,7 @@ export function Function(
           if (
             props.onCall !== undefined &&
             output.function_call !== undefined &&
-            output.function_call.name === name &&
+            output.function_call.name === props.name &&
             output.function_call.arguments !== undefined
           ) {
             await props.onCall(output.function_call.arguments);

--- a/priompt/src/index.ts
+++ b/priompt/src/index.ts
@@ -5,4 +5,4 @@ export * from './components';
 export { PreviewManager, dumpProps, register } from './preview';
 export type { PreviewManagerGetPromptQuery, PreviewManagerLiveModeQuery, PreviewManagerLiveModeResultQuery, PreviewConfig } from './preview';
 
-export type { RenderOptions, RenderOutput, JSX, RenderedPrompt, Prompt, PromptElement, BaseProps, PromptProps, ChatAndFunctionPromptFunction, ChatPrompt } from './types';
+export type { RenderOptions, RenderOutput, JSX, RenderedPrompt, Prompt, PromptNode, PromptElement, BaseProps, PromptProps, ChatAndFunctionPromptFunction, ChatPrompt } from './types';

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -88,7 +88,7 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 		// we scope each tag so we can add priorities to it
 		return {
 			type: 'scope',
-			children: [tag({ ...props, children: children })].flat(),
+			children: [tag({ ...props, children: children })],
 			absolutePriority: (props && typeof props.p === 'number') ? props.p : undefined,
 			relativePriority: (props && typeof props.prel === 'number') ? props.prel : undefined
 		};
@@ -102,7 +102,7 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 			{
 				return {
 					type: 'scope',
-					children: children.flat(),
+					children,
 					relativePriority: (props && typeof props.prel === 'number') ? props.prel : undefined,
 					absolutePriority: (props && typeof props.p === 'number') ? props.p : undefined,
 					onEject: props && typeof props.onEject === 'function' ? props.onEject as () => void : undefined,
@@ -149,14 +149,13 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 			}
 		case 'first':
 			{
-				const newChildren: Scope[] = [];
 				// assert that all children are scopes
-				for (const child of children.flat()) {
+				const newChildren: Scope[] = children.map(child => {
 					if (child === null || typeof child !== 'object' || !("type" in child) || child.type !== 'scope') {
 						throw new Error(`first tag must have only scope children, got ${child}`);
 					}
-					newChildren.push(child);
-				}
+					return child;
+				});
 				return {
 					type: 'first',
 					children: newChildren,
@@ -196,7 +195,7 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 						type: 'isolate',
 						tokenLimit: props.tokenLimit,
 						cachedRenderOutput: undefined,
-						children: children.flat(),
+						children,
 					}],
 					absolutePriority: (typeof props.p === 'number') ? props.p : undefined,
 					relativePriority: (typeof props.prel === 'number') ? props.prel : undefined
@@ -232,7 +231,7 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 }
 
 export function Fragment({ children }: { children: PromptNode; }): PromptElement {
-	const childrenToPass = Array.isArray(children) ? children.flat() : [children];
+	const childrenToPass = Array.isArray(children) ? children : [children];
 	return {
 		type: "scope",
 		children: childrenToPass,

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -1415,7 +1415,7 @@ function validateUnrenderedPrompt(elem: PromptNode): void {
 
 function validateNotBothAbsoluteAndRelativePriority(elem: PromptNode): void {
 	if (Array.isArray(elem)) {
-		elem.forEach(e => validateUnrenderedPrompt(e));
+		elem.forEach(e => validateNotBothAbsoluteAndRelativePriority(e));
 		return;
 	}
 
@@ -1459,9 +1459,7 @@ function validateNotBothAbsoluteAndRelativePriority(elem: PromptNode): void {
 
 function validateNoChildrenHigherPriorityThanParent(elem: PromptNode, parentPriority: number = BASE_PRIORITY): void {
 	if (Array.isArray(elem)) {
-		for (const child of elem) {
-			validateNoChildrenHigherPriorityThanParent(child, parentPriority);
-		}
+		elem.forEach(e => validateNoChildrenHigherPriorityThanParent(e, parentPriority));
 		return;
 	}
 

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -1544,6 +1544,7 @@ function computePriorityLevels(elem: AnyNode, parentPriority: number, levels: Se
 			levels.add(priority);
 			// we make the elem have this priority, so that we don't need to redo the priority calculation
 			elem.absolutePriority = priority;
+			// then for children
 			computePriorityLevels(elem.children, priority, levels);
 			return;
 		}

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -230,13 +230,8 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 	}
 }
 
-export function Fragment({ children }: { children: PromptNode; }): PromptElement {
-	return {
-		type: "scope",
-		absolutePriority: undefined,
-		relativePriority: undefined,
-		children,
-	};
+export function Fragment({ children }: { children: PromptNode; }): PromptNode {
+	return children;
 }
 
 // priority level if it is not set becomes 1e9, i.e. it is always rendered

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -1434,9 +1434,7 @@ function validateNotBothAbsoluteAndRelativePriority(elem: PromptNode): void {
 		case 'chat':
 		case 'isolate':
 		case 'first': {
-			if (Array.isArray(elem.children)) {
-				elem.children.forEach(child => validateNotBothAbsoluteAndRelativePriority(child));
-			}
+			validateNotBothAbsoluteAndRelativePriority(elem.children);
 			return;
 		}
 		case 'capture':
@@ -1449,9 +1447,7 @@ function validateNotBothAbsoluteAndRelativePriority(elem: PromptNode): void {
 			if (elem.absolutePriority !== undefined && elem.relativePriority !== undefined) {
 				console.warn(`Priompt WARNING: scope has both absolute and relative priority.This is discouraged.Ignoring relative priority.`);
 			}
-			if (Array.isArray(elem.children)) {
-				elem.children.forEach(child => validateNotBothAbsoluteAndRelativePriority(child));
-			}
+			validateNotBothAbsoluteAndRelativePriority(elem.children);
 			return;
 		}
 	}
@@ -1477,9 +1473,7 @@ function validateNoChildrenHigherPriorityThanParent(elem: PromptNode, parentPrio
 	switch (elem.type) {
 		case 'chat':
 		case 'first': {
-			if (Array.isArray(elem.children)) {
-				elem.children.forEach(child => validateNoChildrenHigherPriorityThanParent(child, parentPriority));
-			}
+			validateNoChildrenHigherPriorityThanParent(elem.children, parentPriority);
 			return;
 		}
 		case 'isolate': {
@@ -1498,9 +1492,7 @@ function validateNoChildrenHigherPriorityThanParent(elem: PromptNode, parentPrio
 			if (priority > parentPriority) {
 				console.warn(`Priompt WARNING: child scope has a higher priority(${priority}) than its parent(${parentPriority}).This is discouraged, because the child will only be included if the parent is, and thus the effective priority of the child is just the parent's priority.`);
 			}
-			if (Array.isArray(elem.children)) {
-				elem.children.forEach(child => validateNoChildrenHigherPriorityThanParent(child, priority));
-			}
+			validateNoChildrenHigherPriorityThanParent(elem.children, priority);
 			return;
 		}
 	}
@@ -1535,10 +1527,8 @@ function computePriorityLevels(elem: AnyNode, parentPriority: number, levels: Se
 	switch (elem.type) {
 		case 'chat':
 		case 'first': {
-			// just do it for each child
-			if (Array.isArray(elem.children)) {
-				elem.children.forEach(child => computePriorityLevels(child, parentPriority, levels));
-			}
+			// just do it for children
+			computePriorityLevels(elem.children, parentPriority, levels);
 			return;
 		}
 		case 'capture':
@@ -1559,9 +1549,7 @@ function computePriorityLevels(elem: AnyNode, parentPriority: number, levels: Se
 			levels.add(priority);
 			// we make the elem have this priority, so that we don't need to redo the priority calculation
 			elem.absolutePriority = priority;
-			if (Array.isArray(elem.children)) {
-				elem.children.forEach(child => computePriorityLevels(child, priority, levels));
-			}
+			computePriorityLevels(elem.children, priority, levels);
 			return;
 		}
 		case 'normalizedString': {

--- a/priompt/src/lib.ts
+++ b/priompt/src/lib.ts
@@ -231,12 +231,11 @@ export function createElement(tag: ((props: BaseProps & Record<string, unknown>)
 }
 
 export function Fragment({ children }: { children: PromptNode; }): PromptElement {
-	const childrenToPass = Array.isArray(children) ? children : [children];
 	return {
 		type: "scope",
-		children: childrenToPass,
 		absolutePriority: undefined,
 		relativePriority: undefined,
+		children,
 	};
 }
 

--- a/priompt/src/preview.ts
+++ b/priompt/src/preview.ts
@@ -1,5 +1,5 @@
 import { render } from './lib';
-import { Prompt, PromptElement, PromptProps, RenderOutput } from './types';
+import { Prompt, PromptNode, PromptProps, RenderOutput } from './types';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
@@ -44,7 +44,7 @@ type LiveModeOutput = {
 
 type LiveModeData = {
   liveModeId: string;
-  promptElement: PromptElement;
+  promptElement: PromptNode;
 };
 
 function getProjectRoot(): string {
@@ -52,7 +52,7 @@ function getProjectRoot(): string {
   return process.cwd();
 }
 
-export function configFromPrompt<T, ReturnT = never>(prompt: (props: PromptProps<T, ReturnT>) => PromptElement): PreviewConfig<T> {
+export function configFromPrompt<T, ReturnT = never>(prompt: (props: PromptProps<T, ReturnT>) => PromptNode): PreviewConfig<T> {
   return {
     id: prompt.name,
     prompt,
@@ -71,7 +71,7 @@ export function dumpProps<T, ReturnT = never>(config: PreviewConfig<T, ReturnT>,
 
 export type PreviewConfig<PropsT, ReturnT = never> = {
   id: string;
-  prompt: (props: PromptProps<PropsT, ReturnT>) => PromptElement;
+  prompt: (props: PromptProps<PropsT, ReturnT>) => PromptNode;
   // defaults to yaml but can be overridden
   dump?: (props: Omit<PropsT, "onReturn">) => string; hydrate?: (dump: string) => PropsT;
 }
@@ -162,7 +162,7 @@ class PreviewManagerImpl implements IPreviewManager {
 
   }
 
-  private getElement(promptId: string, propsId: string, outputCatcher?: OutputCatcher<unknown>): PromptElement {
+  private getElement(promptId: string, propsId: string, outputCatcher?: OutputCatcher<unknown>): PromptNode {
     if (promptId === 'liveModePromptId') {
       if (this.lastLiveModeData === null) {
         throw new Error('live mode prompt not found');
@@ -213,7 +213,7 @@ class PreviewManagerImpl implements IPreviewManager {
     return props;
   }
 
-  maybeDump<T, ReturnT = never>(prompt: (props: PromptProps<T, ReturnT>) => PromptElement, props: Omit<T, "onReturn">) {
+  maybeDump<T, ReturnT = never>(prompt: (props: PromptProps<T, ReturnT>) => PromptNode, props: Omit<T, "onReturn">) {
     if (!this.shouldDump) {
       return;
     }
@@ -261,7 +261,7 @@ class PreviewManagerImpl implements IPreviewManager {
     });
   }
 
-  async getLiveModePromptCompletion(promptElement: PromptElement, options: { model: string, abortSignal?: AbortSignal }): Promise<CreateChatCompletionResponse> {
+  async getLiveModePromptCompletion(promptElement: PromptNode, options: { model: string, abortSignal?: AbortSignal }): Promise<CreateChatCompletionResponse> {
     const liveModeData: LiveModeData = {
       liveModeId: randomString(),
       promptElement,
@@ -290,7 +290,7 @@ class PreviewManagerImpl implements IPreviewManager {
     return output;
   }
 
-  async *streamLiveModePromptCompletion(promptElement: PromptElement, options: { model: string, abortSignal?: AbortSignal }): AsyncGenerator<StreamChatCompletionResponse> {
+  async *streamLiveModePromptCompletion(promptElement: PromptNode, options: { model: string, abortSignal?: AbortSignal }): AsyncGenerator<StreamChatCompletionResponse> {
     const output: StreamChatCompletionResponse = await this.getLiveModePromptCompletion(promptElement, options);
 
     output.choices[0].delta = output.choices[0].message;


### PR DESCRIPTION
This PR makes `PromptNode` and `PromptElement`  types more similar to `React.ReactNode` and `React.ReactElement`, respectively. That is, the `PromptElement` type now encapsulates all the internal object representations of elements created through `Prompt.createElement` and JSX transpilation, and `PromptNode` now encapsulates all types that can be rendered (the `PromptElement` type in addition to literal types like strings and numbers).

Fixing these types allows some `Array.prototype.flat()` calls that were used to wrangle with Typescript to be removed.

NOTE: This change may require changing the return types of Priompt components from `PromptElement` to `PromptNode`. For example, the following would cause a type error because the `PromptElement` type does not include strings, even though `ExamplePrompt` is a renderable component.

```tsx
function ExamplePrompt(): PromptElement {
  return "Hello!";
}
```
Changing the `PromptElement` type to `PromptNode` would fix this type error.