### PR TITLE
Remove @ts-ignores from tests

### DIFF
--- a/priompt/src/base.test.tsx
+++ b/priompt/src/base.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as Priompt from "./lib";
+import * as Priompt from "./index";
 import {
   isChatPrompt,
   isPlainPrompt,

--- a/priompt/src/base.test.tsx
+++ b/priompt/src/base.test.tsx
@@ -17,24 +17,16 @@ describe("isolate", () => {
     if (props.isolate) {
       return (
         <>
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <isolate p={props.p} prel={props.prel} tokenLimit={props.tokenLimit}>
             {props.children}
-            {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           </isolate>
         </>
       );
     } else {
       return (
         <>
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <scope p={props.p} prel={props.prel}>
             {props.children}
-            {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           </scope>
         </>
       );
@@ -45,41 +37,27 @@ describe("isolate", () => {
     return (
       <>
         This is the start of the prompt.
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <Isolate tokenLimit={100} isolate={props.isolate}>
           {Array.from({ length: 1000 }, (_, i) => (
             <>
-              {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
               <scope prel={-i - 2000}>
                 This is an SHOULDBEINCLUDEDONLYIFISOLATED user message number{" "}
                 {i}
-                {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
               </scope>
             </>
           ))}
         </Isolate>
         {Array.from({ length: 1000 }, (_, i) => (
           <>
-            {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
             <scope prel={-i - 1000}>This is user message number {i}</scope>
           </>
         ))}
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <Isolate tokenLimit={100} isolate={props.isolate}>
           {Array.from({ length: 1000 }, (_, i) => (
             <>
-              {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
               <scope prel={-i}>
                 {i},xl,x,,
                 {i > 100 ? "SHOULDBEINCLUDEDONLYIFNOTISOLATED" : ""}
-                {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
               </scope>
             </>
           ))}
@@ -123,10 +101,7 @@ describe("isolate", () => {
   ): PromptElement {
     return (
       <>
-        This is the start of the p
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
-        {props.breaktoken ? <breaktoken /> : <></>}
+        This is the start of the p{props.breaktoken ? <breaktoken /> : <></>}
         rompt. This is the second part of the prompt.
       </>
     );
@@ -162,23 +137,13 @@ describe("isolate", () => {
   ): PromptElement {
     return (
       <>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <SystemMessage>
           This is the start of the prompt.
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           {props.breaktoken ? <breaktoken /> : <></>}
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
           This is the second part of the prompt.
         </SystemMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage>hi!</UserMessage>
       </>
     );
@@ -219,14 +184,8 @@ describe("isolate", () => {
   function SpecialTokensPrompt(): PromptElement {
     return (
       <>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <SystemMessage>{"<|im_start|>"}</SystemMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage>{"<|diff_marker|>"}</UserMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <AssistantMessage>{"<|endoftext|>"}</AssistantMessage>
       </>
     );
@@ -251,11 +210,7 @@ describe("config", () => {
     return (
       <>
         This is the start of the prompt.
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <config stop={"\n"} />
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <config maxResponseTokens="tokensReserved" />
       </>
     );

--- a/priompt/src/components.test.tsx
+++ b/priompt/src/components.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as Priompt from "./lib";
+import * as Priompt from "./index";
 import {
   isChatPrompt,
   isPlainPrompt,
@@ -19,8 +19,6 @@ import { PromptElement, PromptProps } from "./types";
 
 describe("SystemMessage", () => {
   function TestSystemMessage(props: PromptProps): PromptElement {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return <SystemMessage>hi this is a system message</SystemMessage>;
   }
 
@@ -35,22 +33,14 @@ describe("SystemMessage", () => {
   function TestSystemMessageWithName(
     props: PromptProps<{ systemName?: string; userName?: string }>
   ): PromptElement {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return (
       <>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <SystemMessage name={props.systemName}>
           hi this is a system message
         </SystemMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage name={props.userName}>
           hi this is a user message
         </UserMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage>hi this is a user message</UserMessage>
       </>
     );
@@ -91,12 +81,8 @@ describe("SystemMessage", () => {
 
 describe("Function", () => {
   function TestFunction(props: PromptProps): PromptElement {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return (
       <>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <Function
           name={"echo"}
           description={"Echo a message to the user."}
@@ -111,8 +97,6 @@ describe("Function", () => {
             required: ["message"],
           }}
         />
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage>say hi</UserMessage>
       </>
     );
@@ -147,12 +131,8 @@ describe("Function", () => {
 
 describe("All kinds of messages", () => {
   function TestAllMessages(props: PromptProps): PromptElement {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return (
       <>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <Function
           name={"echo"}
           description={"Echo a message to the user."}
@@ -167,22 +147,14 @@ describe("All kinds of messages", () => {
             required: ["message"],
           }}
         />
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <SystemMessage>System message</SystemMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage>User message</UserMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <AssistantMessage
           functionCall={{
             name: "echo",
             arguments: '{"message": "this is a test echo"}',
           }}
         ></AssistantMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <FunctionMessage name={"echo"}>this is a test echo</FunctionMessage>
       </>
     );
@@ -240,40 +212,24 @@ describe("All kinds of messages", () => {
 
 describe("Images", () => {
   function TestImageMessage(props: PromptProps): PromptElement {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return (
       <>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <SystemMessage>System message</SystemMessage>
-        {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
         <UserMessage>
           <ImageComponent
             bytes={new Uint8Array([0, 0, 0, 0, 0])}
             dimensions={{ width: 10, height: 10 }}
             detail="auto"
           />
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
           If the instructions mention this image, use it to help you write the
           code with the utmost precision and detail.
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
           {"<instructions>"}
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
           TEST, THIS IS A TEST,
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
           {"</instructions>"}
-          {/* // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore */}
           <br />
         </UserMessage>
       </>

--- a/priompt/src/index.ts
+++ b/priompt/src/index.ts
@@ -5,4 +5,4 @@ export * from './components';
 export { PreviewManager, dumpProps, register } from './preview';
 export type { PreviewManagerGetPromptQuery, PreviewManagerLiveModeQuery, PreviewManagerLiveModeResultQuery, PreviewConfig, SynchronousPreviewConfig } from './preview';
 
-export type { RenderOptions, RenderOutput, RenderedPrompt, Prompt, PromptElement, BaseProps, PromptProps, ChatAndFunctionPromptFunction, ChatPrompt } from './types';
+export type { RenderOptions, RenderOutput, JSX, RenderedPrompt, Prompt, PromptElement, BaseProps, PromptProps, ChatAndFunctionPromptFunction, ChatPrompt } from './types';

--- a/priompt/src/index.ts
+++ b/priompt/src/index.ts
@@ -5,4 +5,4 @@ export * from './components';
 export { PreviewManager, dumpProps, register } from './preview';
 export type { PreviewManagerGetPromptQuery, PreviewManagerLiveModeQuery, PreviewManagerLiveModeResultQuery, PreviewConfig, SynchronousPreviewConfig } from './preview';
 
-export type { RenderOptions, RenderOutput, JSX, RenderedPrompt, Prompt, PromptElement, BaseProps, PromptProps, ChatAndFunctionPromptFunction, ChatPrompt } from './types';
+export type { RenderOptions, RenderOutput, RenderedPrompt, Prompt, PromptElement, BaseProps, PromptProps, ChatAndFunctionPromptFunction, ChatPrompt } from './types';

--- a/priompt/src/types.d.ts
+++ b/priompt/src/types.d.ts
@@ -145,24 +145,22 @@ export type ReturnProps<T> = {
 type BasePromptProps<T = Record<never, never>> = (keyof T extends never ? BaseProps : BaseProps & T);
 export type PromptProps<T = Record<never, never>, ReturnT = never> = ([ReturnT] extends [never] ? BasePromptProps<T> : BasePromptProps<T> & ReturnProps<ReturnT>);
 
-declare global {
-	namespace JSX {
-		interface IntrinsicElements {
-			scope: BaseProps;
-			br: Omit<BaseProps, 'children'>;
-			hr: Omit<BaseProps, 'children'>;
-			breaktoken: Omit<BaseProps, 'children'>;
-			// automatically use a certain number of tokens (useful for leaving space for the model to give its answer)
-			empty: BaseProps & { tokens: number; };
-			first: Omit<Omit<BaseProps, 'p'>, 'prel'>;
-			capture: Omit<BaseProps, 'children'> & CaptureProps;
-			isolate: BaseProps & IsolateProps;
-			config: Omit<BaseProps, 'children'> & ConfigProps;
-		}
-		type Element = PromptElement;
-		interface ElementAttributesProperty {
-			props: BaseProps; // specify the property name to use
-		}
+export namespace JSX {
+	interface IntrinsicElements {
+		scope: BaseProps;
+		br: Omit<BaseProps, 'children'>;
+		hr: Omit<BaseProps, 'children'>;
+		breaktoken: Omit<BaseProps, 'children'>;
+		// automatically use a certain number of tokens (useful for leaving space for the model to give its answer)
+		empty: BaseProps & { tokens: number; };
+		first: Omit<Omit<BaseProps, 'p'>, 'prel'>;
+		capture: Omit<BaseProps, 'children'> & CaptureProps;
+		isolate: BaseProps & IsolateProps;
+		config: Omit<BaseProps, 'children'> & ConfigProps;
+	}
+	type Element = PromptElement;
+	interface ElementAttributesProperty {
+		props: BaseProps; // specify the property name to use
 	}
 }
 

--- a/priompt/src/types.d.ts
+++ b/priompt/src/types.d.ts
@@ -145,22 +145,24 @@ export type ReturnProps<T> = {
 type BasePromptProps<T = Record<never, never>> = (keyof T extends never ? BaseProps : BaseProps & T);
 export type PromptProps<T = Record<never, never>, ReturnT = never> = ([ReturnT] extends [never] ? BasePromptProps<T> : BasePromptProps<T> & ReturnProps<ReturnT>);
 
-export namespace JSX {
-	interface IntrinsicElements {
-		scope: BaseProps;
-		br: Omit<BaseProps, 'children'>;
-		hr: Omit<BaseProps, 'children'>;
-		breaktoken: Omit<BaseProps, 'children'>;
-		// automatically use a certain number of tokens (useful for leaving space for the model to give its answer)
-		empty: BaseProps & { tokens: number; };
-		first: Omit<Omit<BaseProps, 'p'>, 'prel'>;
-		capture: Omit<BaseProps, 'children'> & CaptureProps;
-		isolate: BaseProps & IsolateProps;
-		config: Omit<BaseProps, 'children'> & ConfigProps;
-	}
-	type Element = PromptElement;
-	interface ElementAttributesProperty {
-		props: BaseProps; // specify the property name to use
+declare global {
+	namespace JSX {
+		interface IntrinsicElements {
+			scope: BaseProps;
+			br: Omit<BaseProps, 'children'>;
+			hr: Omit<BaseProps, 'children'>;
+			breaktoken: Omit<BaseProps, 'children'>;
+			// automatically use a certain number of tokens (useful for leaving space for the model to give its answer)
+			empty: BaseProps & { tokens: number; };
+			first: Omit<Omit<BaseProps, 'p'>, 'prel'>;
+			capture: Omit<BaseProps, 'children'> & CaptureProps;
+			isolate: BaseProps & IsolateProps;
+			config: Omit<BaseProps, 'children'> & ConfigProps;
+		}
+		type Element = PromptElement;
+		interface ElementAttributesProperty {
+			props: BaseProps; // specify the property name to use
+		}
 	}
 }
 


### PR DESCRIPTION
This allows the `JSX` namespace to be resolved in the tests file, removing the need for `ts-ignore`s.